### PR TITLE
Remove commented-out codecov step referencing secrets

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,11 +20,6 @@ jobs:
         run: |
           echo "running unit tests"
           pixi run test
-      # - name: upload coverage to codecov
-      #   uses: codecov/codecov-action@v5
-      #   if: github.actor != 'dependabot[bot]'
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
       - name: build conda package
         run: |
           echo "build and verify conda package"


### PR DESCRIPTION
## Summary
- Removed commented-out codecov workflow step that referenced `secrets.CODECOV_TOKEN`
- Commented-out workflow code with secret references is a maintenance hazard — if partially uncommented it could expose secrets to fork/Dependabot PRs
- Can be restored from git history if codecov integration is needed later

## Test plan
- [ ] Verify CI still passes without the removed comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)