### PR TITLE
ci: drop v0.41.4 pixi-version pin in unittest and package workflows

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.41.4
           manifest-path: pyproject.toml
       - name: build conda package
         run: |
@@ -41,7 +40,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.41.4
           manifest-path: pyproject.toml
       - name: build pypi package
         run: |

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.41.4
           manifest-path: pyproject.toml
       - name: run unit tests
         run: |


### PR DESCRIPTION
## Summary
- Removes the `pixi-version: v0.41.4` pin in `unittest.yml` (1 occurrence) and `package.yml` (2 occurrences) so they use the default pixi installed by `prefix-dev/setup-pixi`.

## Why
`update-lockfiles.yml` is unpinned and uses the latest pixi (which now produces lockfile version 7). The pinned test/package workflows on v0.41.4 only read older lockfile versions, so the next auto-regen of `pixi.lock` would break CI. This is the same root cause as the recent timepix_geometry_correction breakage (fixed in that repo's PR #70).

## Test plan
- [ ] Unit tests CI passes on this PR
- [ ] Conda build job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)