### PR TITLE
security: pin third-party GitHub Actions to commit SHAs + least-privilege permissions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           manifest-path: pyproject.toml
       - name: build conda package
@@ -38,7 +38,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           manifest-path: pyproject.toml
       - name: build pypi package
@@ -49,4 +49,4 @@ jobs:
       # publish your distributions here (need to setup on PyPI first)
       - name: Publish package distributions to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,12 +7,15 @@ on:
     branches: [next, qa, main]
     tags: ['v*']
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           manifest-path: pyproject.toml
       - name: run unit tests

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           run-install: false
       - name: Update lockfiles
@@ -23,7 +23,7 @@ jobs:
           set -o pipefail
           pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update pixi lockfile


### PR DESCRIPTION
## What

Supply-chain hardening of GitHub Actions workflows:

- **SHA-pin all third-party actions** to full 40-char commit SHAs, retaining a trailing `# version` comment for readability.
- **Add a conservative top-level `permissions: contents: read`** block to pure-CI workflows that have no existing top-level permissions block and use no privileged features.

First-party `actions/*` and `github/*` actions are intentionally left tag-pinned per group convention.

## Why

Pinning third-party actions to immutable commit SHAs protects against tag-hijacking / mutable-tag supply-chain attacks. Least-privilege default permissions limit the blast radius of a compromised action. From the 2026-06-22 workspace GitHub Actions security audit.

## Pins applied

| Action | Pinned SHA |
| --- | --- |
| `prefix-dev/setup-pixi@v0.9.6` | `5185adfbffb4bd703da3010310260805d89ebb11` |
| `peter-evans/create-pull-request@v8` | `5f6978faf089d4d20b00c7766989d076bb2fc7f1` |
| `pypa/gh-action-pypi-publish@release/v1` | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` (v1.14.0) |

(4 occurrences total across 3 files: setup-pixi appears in all three files — twice in `package.yml`.)

## Permissions

- `unittest.yml` — added top-level `permissions: contents: read` (pure CI, no privileged features).
- `package.yml` — **not modified** (release pipeline uses `id-token`, `anaconda upload`, `gh-action-pypi-publish`); keeps its existing job-level `id-token: write`.
- `update-lockfiles.yml` — **not modified** (already has a top-level `permissions:` block and uses `peter-evans/create-pull-request`).

## Notes

- No `dtolnay/rust-toolchain` or `taiki-e/install-action` usages exist in this repo, so those special-case rules did not apply.
- No behavior change intended; CI on this PR validates.

🤖 Assisted with Claude Code
