### PR TITLE
ci(update-lockfiles): open lockfile PR with a GitHub App token

### DIFF
--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -13,6 +13,17 @@ jobs:
   pixi-update:
     runs-on: ubuntu-latest
     steps:
+      # Mint an App installation token so the PR is created by the App identity,
+      # not GITHUB_TOKEN. PRs opened with GITHUB_TOKEN cannot trigger other
+      # workflows (GitHub recursion guard), which left the lockfile PR CI held
+      # on "Approve and run"; an App token opens the PR as a first-class PR.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.LOCKFILE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LOCKFILE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
@@ -25,7 +36,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: Update pixi lockfile
           title: Update pixi lockfile
           body-path: diff.md


### PR DESCRIPTION
Fixes the recurring **"Approve and run"** hold on the monthly *Update lockfiles* PRs.

**Why:** a PR created with the built-in `GITHUB_TOKEN` cannot trigger other workflows (GitHub's recursion guard), so the lockfile PR's checks never ran until a maintainer clicked "Approve and run".

**Change:** mint a GitHub App installation token (`actions/create-github-app-token`, SHA-pinned v3.2.0) and hand it to `peter-evans/create-pull-request`, so the lockfile PR opens as the App identity and its CI runs automatically — after which it can flow through auto-merge.

**Verified end-to-end** on CylindricalGeometryCorrection #77: the App-created lockfile PR triggered CI with no "Approve and run" hold.

**Requires** (org-level, already provisioned): variable `LOCKFILE_APP_CLIENT_ID` + secret `LOCKFILE_APP_PRIVATE_KEY`; App installed with Contents + Pull requests: write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
