### PR TITLE
Fix Update lockfiles PR base branch (main -> next)

### DIFF
--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -41,7 +41,7 @@ jobs:
           title: Update pixi lockfile
           body-path: diff.md
           branch: update-pixi
-          base: main  # change this to the default branch of your repository
+          base: next  # Default branch for this repository
           labels: pixi
           delete-branch: true
           add-paths: pixi.lock


### PR DESCRIPTION
## Problem

`.github/workflows/update-lockfiles.yml` still carried the project-template placeholder:

```yaml
base: main  # change this to the default branch of your repository
```

This repository's default branch is **`next`**, and that line was never changed.

`actions/checkout` checks out the default branch (`next`), `pixi update` regenerates `pixi.lock` from it, and then `peter-evans/create-pull-request` tried to apply that commit onto `main`. `next` is **123 commits ahead** of `main`, and `pixi.lock` does not exist on `main` at all (the branch compare shows `pixi.lock` as +11880/-0), so the cherry-pick could never apply:

```
##[error]Unexpected error: error: could not apply ff7ba72... Update pixi lockfile
hint: After resolving the conflicts, mark them with "git add/rm <pathspec>"...
```

Both scheduled runs failed at step 5, "Create pull request":

| run | date | result |
| --- | --- | --- |
| [26739328404](https://github.com/ornlneutronimaging/RootPlantProcessing/actions/runs/26739328404) | 2026-06-01 | failure |
| [28498376353](https://github.com/ornlneutronimaging/RootPlantProcessing/actions/runs/28498376353) | 2026-07-01 | failure |

Steps 1-4 (App token, checkout, pixi setup, `pixi update`) all succeeded every time — only the PR creation failed. So **no pixi lockfile PR has ever been opened** and dependency updates have been silently dropped since the workflow was added.

## Fix

Point `base` at `next`, the branch the lockfile is actually generated from. One line, no behavior change beyond the target branch. The stale "change this to..." placeholder comment is replaced with the same wording `CylindricalGeometryCorrection` already uses.

This was the only `base:`/default-branch mismatch in the fleet — the lockfile workflows in BraggEdge, HyperCTui, iBeatles, CylindricalGeometryCorrection, AvantVENUS, timepix_geometry_correction and marimo_notebooks all already match their default branch.

## Verification

Found during the daily bot-PR/security scan. Verified by dispatching `Update lockfiles` against this branch — see the run linked in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)